### PR TITLE
Fix the rake tests

### DIFF
--- a/lib/elasticrawl/crawl_segment.rb
+++ b/lib/elasticrawl/crawl_segment.rb
@@ -16,7 +16,7 @@ module Elasticrawl
 
       segment = CrawlSegment.where(:crawl_id => crawl.id,
                                   :segment_name => segment_name,
-                                  :segment_s3_uri => s3_uri,
+                                  :segment_s3_uri => s3_uri.to_s,
                                   :file_count => file_count).first_or_create
     end
 


### PR DESCRIPTION
Not sure if this is exactly the right fix. I'm pretty new to Ruby, but I tried running `rake` and it seems most of the tests are failing:

> 72 examples, 38 failures

Looks like every test failure is the same root cause:

```
  TypeError:
    can't cast URI::Generic to string
  # /home/bmccann/.rvm/gems/ruby-2.1.4/gems/activerecord-4.2.3/lib/active_record/connection_adapters/abstract/quoting.rb:34:in `rescue in type_cast'
  # /home/bmccann/.rvm/gems/ruby-2.1.4/gems/activerecord-4.2.3/lib/active_record/connection_adapters/abstract/quoting.rb:23:in `type_cast'
  # /home/bmccann/.rvm/gems/ruby-2.1.4/gems/activerecord-4.2.3/lib/active_record/connection_adapters/sqlite3_adapter.rb:290:in `block in exec_query'
  # /home/bmccann/.rvm/gems/ruby-2.1.4/gems/activerecord-4.2.3/lib/active_record/connection_adapters/sqlite3_adapter.rb:289:in `map'
  # /home/bmccann/.rvm/gems/ruby-2.1.4/gems/activerecord-4.2.3/lib/active_record/connection_adapters/sqlite3_adapter.rb:289:in `exec_query'
  # /home/bmccann/.rvm/gems/ruby-2.1.4/gems/activerecord-4.2.3/lib/active_record/connection_adapters/abstract/database_statements.rb:351:in `select'
  # /home/bmccann/.rvm/gems/ruby-2.1.4/gems/activerecord-4.2.3/lib/active_record/connection_adapters/abstract/database_statements.rb:32:in `select_all'
  # /home/bmccann/.rvm/gems/ruby-2.1.4/gems/activerecord-4.2.3/lib/active_record/connection_adapters/abstract/query_cache.rb:70:in `select_all'
  # /home/bmccann/.rvm/gems/ruby-2.1.4/gems/activerecord-4.2.3/lib/active_record/querying.rb:39:in `find_by_sql'
  # /home/bmccann/.rvm/gems/ruby-2.1.4/gems/activerecord-4.2.3/lib/active_record/relation.rb:638:in `exec_queries'
  # /home/bmccann/.rvm/gems/ruby-2.1.4/gems/activerecord-4.2.3/lib/active_record/relation.rb:514:in `load'
  # /home/bmccann/.rvm/gems/ruby-2.1.4/gems/activerecord-4.2.3/lib/active_record/relation.rb:243:in `to_a'
  # /home/bmccann/.rvm/gems/ruby-2.1.4/gems/activerecord-4.2.3/lib/active_record/relation/finder_methods.rb:500:in `find_nth_with_limit'
  # /home/bmccann/.rvm/gems/ruby-2.1.4/gems/activerecord-4.2.3/lib/active_record/relation/finder_methods.rb:484:in `find_nth'
  # /home/bmccann/.rvm/gems/ruby-2.1.4/gems/activerecord-4.2.3/lib/active_record/relation/finder_methods.rb:127:in `first'
  # /home/bmccann/.rvm/gems/ruby-2.1.4/gems/activerecord-4.2.3/lib/active_record/relation.rb:155:in `first_or_create'
  # ./lib/elasticrawl/crawl_segment.rb:20:in `create_segment'
```
