### PR TITLE
Add default instance profile and service profile and fix unit tests

### DIFF
--- a/lib/elasticrawl/cluster.rb
+++ b/lib/elasticrawl/cluster.rb
@@ -40,10 +40,14 @@ HERE
         ec2_key_name = config_setting('ec2_key_name')
         placement = config_setting('placement')
         emr_ami_version = config_setting('emr_ami_version')
+        job_flow_role = config_setting('job_flow_role')
+        service_role = config_setting('service_role')
 
         job_flow.ec2_key_name = ec2_key_name if ec2_key_name.present?
         job_flow.placement = placement if placement.present?
         job_flow.ami_version = emr_ami_version if emr_ami_version.present?
+        job_flow.job_flow_role = job_flow_role if job_flow_role.present?
+        job_flow.service_role = service_role if service_role.present?
     end
 
     # Configures the instances that will be launched.  The master group has

--- a/lib/elasticrawl/crawl_segment.rb
+++ b/lib/elasticrawl/crawl_segment.rb
@@ -32,7 +32,7 @@ private
 
       URI::Generic.build(:scheme => 's3',
                          :host => Elasticrawl::COMMON_CRAWL_BUCKET,
-                         :path => s3_path.join('/'))
+                         :path => s3_path.join('/')).to_s
     end
   end
 end

--- a/templates/cluster.yml
+++ b/templates/cluster.yml
@@ -42,3 +42,9 @@ placement: 'us-east-1a'
 
 # The AMI version to use when launching instances.
 emr_ami_version: 'latest'
+
+# Default instance profile
+job_flow_role: 'EMR_EC2_DefaultRole'
+
+# Default service role
+service_role: 'EMR_DefaultRole'


### PR DESCRIPTION
Incoprorate @benmccann's fix for the unit tests on pull request #13 and added the default instance profile and service roles to access the AWS clusters which should fix issue #10.

This fix is based on a recent update to Elasticity's configuration: https://github.com/rslifka/elasticity/pull/82
