### PR TITLE
Added support for Elasticity's ec2_subnet_id parameter.  

### DIFF
--- a/lib/elasticrawl/cluster.rb
+++ b/lib/elasticrawl/cluster.rb
@@ -47,12 +47,14 @@ HERE
         emr_ami_version = config_setting('emr_ami_version')
         job_flow_role = config_setting('job_flow_role')
         service_role = config_setting('service_role')
+        ec2_subnet_id = config_setting('ec2_subnet_id')
 
         job_flow.ec2_key_name = ec2_key_name if ec2_key_name.present?
         job_flow.placement = placement if placement.present?
         job_flow.ami_version = emr_ami_version if emr_ami_version.present?
         job_flow.job_flow_role = job_flow_role if job_flow_role.present?
         job_flow.service_role = service_role if service_role.present?
+        job_flow.ec2_subnet_id = ec2_subnet_id if ec2_subnet_id.present?
     end
 
     # Configures the instances that will be launched.  The master group has

--- a/templates/cluster.yml
+++ b/templates/cluster.yml
@@ -48,3 +48,13 @@ job_flow_role: 'EMR_EC2_DefaultRole'
 
 # Default service role
 service_role: 'EMR_DefaultRole'
+
+# VPC Subnet ID:
+#  1) Create a VPC using the VPC wizard:
+#   https://console.aws.amazon.com/vpc/home?region=us-east-1#vpcs:
+#  2) Visit the Subnets page:
+#   https://console.aws.amazon.com/vpc/home?region=us-east-1#subnets:
+#  3) Copy the 'Subnet ID' column value below.
+#
+#  ** Usage of newer M4 spot instances require a VPC.
+ec2_subnet_id: 'subnet-x7c2ppy9'


### PR DESCRIPTION
A VPC/subnet_id is required to bid on M4 spot instances.
