### PR TITLE
Support EC2 subnet id in config. (Required for new AWS acccounts.)

### DIFF
--- a/lib/elasticrawl/cluster.rb
+++ b/lib/elasticrawl/cluster.rb
@@ -47,7 +47,9 @@ HERE
         emr_ami_version = config_setting('emr_ami_version')
         job_flow_role = config_setting('job_flow_role')
         service_role = config_setting('service_role')
+        ec2_subnet_id = config_setting('ec2_subnet_id')
 
+        job_flow.ec2_subnet_id = ec2_subnet_id if ec2_subnet_id.present?
         job_flow.ec2_key_name = ec2_key_name if ec2_key_name.present?
         job_flow.placement = placement if placement.present?
         job_flow.ami_version = emr_ami_version if emr_ami_version.present?

--- a/templates/cluster.yml
+++ b/templates/cluster.yml
@@ -48,3 +48,6 @@ job_flow_role: 'EMR_EC2_DefaultRole'
 
 # Default service role
 service_role: 'EMR_DefaultRole'
+
+# Subnet ID. Required for new Amazon accounts launching more powerful instance types.
+ec2_subnet_id: 'subnet-name'


### PR DESCRIPTION
Impossible to run EMR jobs without specifying this for newer accounts.